### PR TITLE
Make scrobbler plugin use proxy settings

### DIFF
--- a/mopidy_scrobbler/frontend.py
+++ b/mopidy_scrobbler/frontend.py
@@ -26,9 +26,21 @@ class ScrobblerFrontend(pykka.ThreadingActor, CoreListener):
     def on_start(self):
         try:
             self.lastfm = pylast.LastFMNetwork(
-                api_key=API_KEY, api_secret=API_SECRET,
-                username=self.config['scrobbler']['username'],
-                password_hash=pylast.md5(self.config['scrobbler']['password']))
+                api_key=API_KEY,
+                api_secret=API_SECRET
+            )
+            if self.config.get('proxy'):
+                self.lastfm.enable_proxy(
+                    self.config['proxy']['hostname'],
+                    self.config['proxy']['port']
+                )
+            self.lastfm.username = self.config['scrobbler']['username']
+            self.lastfm.password_hash = pylast.md5(
+                    self.config['scrobbler']['password'])
+            sk_gen = pylast.SessionKeyGenerator(self.lastfm)
+            self.lastfm.session_key = sk_gen.get_session_key(
+                    self.lastfm.username,
+                    self.lastfm.password_hash)
             logger.info('Scrobbler connected to Last.fm')
         except (pylast.NetworkError, pylast.MalformedResponseError,
                 pylast.WSError) as e:


### PR DESCRIPTION
Hello,

I noticed that the plugin was not scrobbling when i was behind a proxy.
So, i made this small change so that the pylast object uses mopidy config's proxy server settings.
