### PR TITLE
Upgrade pylast for SSL support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
         'setuptools',
         'Mopidy >= 0.18',
         'Pykka >= 1.1',
-        'pylast >= 0.5.7',
+        'pylast >= 1.7.0',
     ],
     entry_points={
         'mopidy.ext': [


### PR DESCRIPTION
Upgrade to a version of pylast which supports SSL if available.

Tests pass but I'm not sure I ran them right.