### PR TITLE
Use MD5 hash in mopidy.conf instead of plaintext passwords

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,19 +34,18 @@ Or, if available, install the Debian/Ubuntu package from `apt.mopidy.com
 Configuration
 =============
 
-The extension is enabled by default when it is installed. You just need to add
-your Last.fm username and password to your Mopidy configuration file, typically
-found at ``~/.config/mopidy/mopidy.conf``::
+The extension is enabled by default when it is installed. You just need to add your Last.fm username and the md5 hash of your paasword to your Mopidy configuration file, typically found at ``~/.config/mopidy/mopidy.conf``::
 
     [scrobbler]
     username = alice
-    password = secret
+    password_hash = secret
 
 The following configuration values are available:
 
 - ``scrobbler/enabled``: If the scrobbler extension should be enabled or not.
 - ``scrobbler/username``: Your Last.fm username.
-- ``scrobbler/password``: Your Last.fm password.
+- ``scrobbler/password_hash``: The MD5 hash of your Last.fm password.
+
 
 
 Project resources

--- a/mopidy_scrobbler/__init__.py
+++ b/mopidy_scrobbler/__init__.py
@@ -21,7 +21,7 @@ class Extension(ext.Extension):
     def get_config_schema(self):
         schema = super(Extension, self).get_config_schema()
         schema['username'] = config.String()
-        schema['password'] = config.Secret()
+        schema['password_hash'] = config.Secret()
         return schema
 
     def setup(self, registry):

--- a/mopidy_scrobbler/ext.conf
+++ b/mopidy_scrobbler/ext.conf
@@ -1,4 +1,4 @@
 [scrobbler]
 enabled = true
 username =
-password =
+password_hash =

--- a/mopidy_scrobbler/frontend.py
+++ b/mopidy_scrobbler/frontend.py
@@ -35,7 +35,7 @@ class ScrobblerFrontend(pykka.ThreadingActor, CoreListener):
             self.lastfm = pylast.LastFMNetwork(
                 api_key=API_KEY, api_secret=API_SECRET,
                 username=self.config['scrobbler']['username'],
-                password_hash=self.config['scrobbler']['password_hash'])
+                password_hash=self.config['scrobbler']['password_hash'].lower())
             logger.info('Scrobbler connected to Last.fm')
         except PYLAST_ERRORS as e:
             logger.error('Error during Last.fm setup: %s', e)

--- a/mopidy_scrobbler/frontend.py
+++ b/mopidy_scrobbler/frontend.py
@@ -35,7 +35,7 @@ class ScrobblerFrontend(pykka.ThreadingActor, CoreListener):
             self.lastfm = pylast.LastFMNetwork(
                 api_key=API_KEY, api_secret=API_SECRET,
                 username=self.config['scrobbler']['username'],
-                password_hash=pylast.md5(self.config['scrobbler']['password']))
+                password_hash=self.config['scrobbler']['password_hash'])
             logger.info('Scrobbler connected to Last.fm')
         except PYLAST_ERRORS as e:
             logger.error('Error during Last.fm setup: %s', e)


### PR DESCRIPTION
This requires the user to put the MD5 of their password in the `Scrobbler` section of `mopidy.conf` instead of their plaintext password.