### PR TITLE
Add scrobble_filter to provide a configurable list of URI schemes not…

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,12 +41,14 @@ found at ``~/.config/mopidy/mopidy.conf``::
     [scrobbler]
     username = alice
     password = secret
+    scrobble_filer = list
 
 The following configuration values are available:
 
 - ``scrobbler/enabled``: If the scrobbler extension should be enabled or not.
 - ``scrobbler/username``: Your Last.fm username.
 - ``scrobbler/password``: Your Last.fm password.
+- ``scrobbler/scrobble_filter``: List of uri schemes to not scrobble - eg spotify
 
 
 Project resources

--- a/README.rst
+++ b/README.rst
@@ -41,14 +41,14 @@ found at ``~/.config/mopidy/mopidy.conf``::
     [scrobbler]
     username = alice
     password = secret
-    scrobble_filer = list
+    backend_blacklist = list
 
 The following configuration values are available:
 
 - ``scrobbler/enabled``: If the scrobbler extension should be enabled or not.
 - ``scrobbler/username``: Your Last.fm username.
 - ``scrobbler/password``: Your Last.fm password.
-- ``scrobbler/scrobble_filter``: List of uri schemes to not scrobble - eg spotify
+- ``scrobbler/backend_blacklist``: List of uri schemes to not scrobble - eg spotify
 
 
 Project resources

--- a/mopidy_scrobbler/__init__.py
+++ b/mopidy_scrobbler/__init__.py
@@ -22,7 +22,7 @@ class Extension(ext.Extension):
         schema = super(Extension, self).get_config_schema()
         schema['username'] = config.String()
         schema['password'] = config.Secret()
-        schema['scrobble_filter'] = config.List(optional=True)
+        schema['backend_blacklist'] = config.List(optional=True)
         return schema
 
     def setup(self, registry):

--- a/mopidy_scrobbler/__init__.py
+++ b/mopidy_scrobbler/__init__.py
@@ -22,6 +22,7 @@ class Extension(ext.Extension):
         schema = super(Extension, self).get_config_schema()
         schema['username'] = config.String()
         schema['password'] = config.Secret()
+        schema['scrobble_filter'] = config.List(optional=True)
         return schema
 
     def setup(self, registry):

--- a/mopidy_scrobbler/ext.conf
+++ b/mopidy_scrobbler/ext.conf
@@ -2,3 +2,4 @@
 enabled = true
 username =
 password =
+scrobble_filter =

--- a/mopidy_scrobbler/ext.conf
+++ b/mopidy_scrobbler/ext.conf
@@ -2,4 +2,4 @@
 enabled = true
 username =
 password =
-scrobble_filter =
+backend_blacklist =

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -16,6 +16,7 @@ class ExtensionTest(unittest.TestCase):
         self.assertIn('enabled = true', config)
         self.assertIn('username =', config)
         self.assertIn('password =', config)
+        self.assertIn('scrobble_filter', config)
 
     def test_get_config_schema(self):
         ext = Extension()
@@ -24,6 +25,7 @@ class ExtensionTest(unittest.TestCase):
 
         self.assertIn('username', schema)
         self.assertIn('password', schema)
+        self.assertIn('scrobble_filter', schema)
 
     def test_setup(self):
         ext = Extension()

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -16,7 +16,7 @@ class ExtensionTest(unittest.TestCase):
         self.assertIn('enabled = true', config)
         self.assertIn('username =', config)
         self.assertIn('password =', config)
-        self.assertIn('scrobble_filter', config)
+        self.assertIn('backend_blacklist', config)
 
     def test_get_config_schema(self):
         ext = Extension()
@@ -25,7 +25,7 @@ class ExtensionTest(unittest.TestCase):
 
         self.assertIn('username', schema)
         self.assertIn('password', schema)
-        self.assertIn('scrobble_filter', schema)
+        self.assertIn('backend_blacklist', schema)
 
     def test_setup(self):
         ext = Extension()

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -163,7 +163,7 @@ class FrontendTest(unittest.TestCase):
 
         self.assertEqual(self.frontend.lastfm.scrobble.call_count, 1)
 
-    def test_does_not_scrobble_if_uri_scheme_filtered(self, pylast.mock):
+    def test_does_not_scrobble_if_uri_scheme_filtered(self, pylast_mock):
         self.frontend.lastfm = mock.Mock(spec=pylast.LastFMNetwork)
         track = models.Track(length=880432, uri='spotify:track:1234567890')
         tl_track = models.TlTrack(track=track, tlid=17)

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -163,7 +163,7 @@ class FrontendTest(unittest.TestCase):
 
         self.assertEqual(self.frontend.lastfm.scrobble.call_count, 1)
 
-    def test_does_not_scrobble_if_uri_scheme_filtered(self, plylast.mock):
+    def test_does_not_scrobble_if_uri_scheme_filtered(self, pylast.mock):
         self.frontend.lastfm = mock.Mock(spec=pylast.LastFMNetwork)
         track = models.Track(length=880432, uri='spotify:track:1234567890')
         tl_track = models.TlTrack(track=track, tlid=17)

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -17,7 +17,7 @@ class FrontendTest(unittest.TestCase):
             'scrobbler': {
                 'username': 'alice',
                 'password': 'secret',
-                'scrobble_filter': ['spotify']
+                'backend_blacklist': ['spotify']
             }
         }
         self.frontend = frontend_lib.ScrobblerFrontend(


### PR DESCRIPTION
… not scrobble

This should fix #28, however I've been testing it today and found that even with the Spotify web app scrobbling enabled, I don't see double scrobbles from Mopidy even if mopidy is also scrobbling.

Not sure why this is, perhaps it's only temporary, but adding this as a config value dosn't do any harm.