### PR TITLE
chore: Update mopidy-ext-template v2.2.0

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,4 +1,4 @@
-_commit: v2.1.3
+_commit: v2.2.0
 _src_path: gh:mopidy/mopidy-ext-template
 author_email: stein.magnus@jodal.no
 author_full_name: Stein Magnus Jodal

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,13 +5,14 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   build:
     name: Build
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: hynek/build-and-inspect-python-package@v2
 
   main:
@@ -19,24 +20,21 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: "pytest (3.11)"
-            python: "3.11"
-            tox: "3.11"
-          - name: "pytest (3.12)"
-            python: "3.12"
-            tox: "3.12"
           - name: "pytest (3.13)"
             python: "3.13"
             tox: "3.13"
+          - name: "pytest (3.14)"
+            python: "3.14"
+            tox: "3.14"
             coverage: true
           - name: "pyright"
-            python: "3.13"
+            python: "3.14"
             tox: "pyright"
           - name: "ruff check"
-            python: "3.13"
+            python: "3.14"
             tox: "ruff-check"
           - name: "ruff format"
-            python: "3.13"
+            python: "3.14"
             tox: "ruff-format"
 
     name: ${{ matrix.name }}
@@ -44,10 +42,10 @@ jobs:
     container: ghcr.io/mopidy/ci:latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Fix home dir permissions to enable pip caching
         run: chown -R root /github/home
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
           cache: pip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: hynek/build-and-inspect-python-package@v2
         id: build
       - uses: actions/download-artifact@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "mopidy-scrobbler"
 description = "Mopidy extension for scrobbling played tracks to Last.fm"
 readme = "README.md"
-requires-python = ">= 3.11"
+requires-python = ">= 3.13"
 license = { text = "Apache-2.0" }
 authors = [{ name = "Stein Magnus Jodal", email = "stein.magnus@jodal.no" }]
 classifiers = [
@@ -13,7 +13,11 @@ classifiers = [
     "Topic :: Multimedia :: Sound/Audio :: Players",
 ]
 dynamic = ["version"]
-dependencies = ["mopidy >= 4.0.0a4", "pykka >= 4", "pylast >= 4.2.0"]
+dependencies = [
+    "mopidy >= 4.0.0a7",
+    "pykka >= 4.1",
+    "pylast >= 5.3",
+]
 
 [project.urls]
 Homepage = "https://github.com/mopidy/mopidy-scrobbler"
@@ -23,7 +27,7 @@ scrobbler = "mopidy_scrobbler:Extension"
 
 
 [build-system]
-requires = ["setuptools >= 66", "setuptools-scm >= 7.1"]
+requires = ["setuptools >= 78", "setuptools-scm >= 8.2"]
 build-backend = "setuptools.build_meta"
 
 
@@ -50,7 +54,7 @@ show_missing = true
 
 
 [tool.pyright]
-pythonVersion = "3.11"
+pythonVersion = "3.13"
 typeCheckingMode = "standard"
 # Not all dependencies have type hints:
 reportMissingTypeStubs = false
@@ -68,7 +72,7 @@ filterwarnings = [
 
 
 [tool.ruff]
-target-version = "py311"
+target-version = "py313"
 
 [tool.ruff.lint]
 select = ["ALL"]
@@ -105,7 +109,13 @@ ignore = [
 
 
 [tool.tox]
-env_list = ["3.11", "3.12", "3.13", "pyright", "ruff-check", "ruff-format"]
+env_list = [
+    "3.13",
+    "3.14",
+    "pyright",
+    "ruff-check",
+    "ruff-format",
+]
 
 [tool.tox.env_run_base]
 package = "wheel"

--- a/src/mopidy_scrobbler/__init__.py
+++ b/src/mopidy_scrobbler/__init__.py
@@ -21,6 +21,6 @@ class Extension(ext.Extension):
         return schema
 
     def setup(self, registry) -> None:
-        from .frontend import ScrobblerFrontend
+        from .frontend import ScrobblerFrontend  # noqa: PLC0415
 
         registry.add("frontend", ScrobblerFrontend)


### PR DESCRIPTION
This drops Python 3.11-3.12 support, and adds Python 3.14.