### PR TITLE
feat: Support Libre.fm

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,10 @@
 [![CI build status](https://img.shields.io/github/actions/workflow/status/mopidy/mopidy-scrobbler/ci.yml)](https://github.com/mopidy/mopidy-scrobbler/actions/workflows/ci.yml)
 [![Test coverage](https://img.shields.io/codecov/c/gh/mopidy/mopidy-scrobbler)](https://codecov.io/gh/mopidy/mopidy-scrobbler)
 
-[Mopidy](https://www.mopidy.com/) extension for scrobbling played tracks to [Last.fm](https://www.last.fm/).
+[Mopidy](https://www.mopidy.com/) extension for scrobbling played tracks to
+[Last.fm](https://www.last.fm/) or [Libre.fm](https://libre.fm/).
 
-This extension requires a free user account at Last.fm.
+This extension requires a free user account at Last.fm or Libre.fm.
 
 ## Maintainer wanted
 
@@ -44,16 +45,27 @@ your Last.fm username and password to your Mopidy configuration file:
 
 ```ini
 [scrobbler]
-username = alice
-password = secret
+username = my-last.fm-username
+password = my-last.fm-password
+```
+
+To use Libre.fm instead, you must specify the `network` too:
+
+```ini
+[scrobbler]
+network = librefm
+username = my-libre.fm-username
+password = my-libre.fm-password
 ```
 
 The following configuration values are available:
 
 - `scrobbler/enabled`: If the scrobbler extension should be enabled or not.
   Defaults to enabled.
-- `scrobbler/username`: Your Last.fm username.
-- `scrobbler/password`: Your Last.fm password.
+- `scrobbler/network`: The scrobbling network to use. Can be either `lastfm` or
+  `librefm`. Defaults to `lastfm`.
+- `scrobbler/username`: Your Last.fm or Libre.fm username.
+- `scrobbler/password`: Your Last.fm or Libre.fm password.
 
 ## Project resources
 

--- a/src/mopidy_scrobbler/__init__.py
+++ b/src/mopidy_scrobbler/__init__.py
@@ -16,6 +16,7 @@ class Extension(ext.Extension):
 
     def get_config_schema(self) -> config.ConfigSchema:
         schema = super().get_config_schema()
+        schema["network"] = config.String(choices=["lastfm", "librefm"])
         schema["username"] = config.String()
         schema["password"] = config.Secret()
         return schema

--- a/src/mopidy_scrobbler/ext.conf
+++ b/src/mopidy_scrobbler/ext.conf
@@ -1,4 +1,5 @@
 [scrobbler]
 enabled = true
+network = lastfm
 username =
 password =

--- a/src/mopidy_scrobbler/frontend.py
+++ b/src/mopidy_scrobbler/frontend.py
@@ -29,7 +29,7 @@ MIN_PLAYED_PERCENT = 50
 
 
 class ScrobblerFrontend(pykka.ThreadingActor, CoreListener):
-    lastfm: pylast.LastFMNetwork
+    network: pylast.LastFMNetwork
     last_start_time: dt.datetime | None
 
     @override
@@ -47,7 +47,7 @@ class ScrobblerFrontend(pykka.ThreadingActor, CoreListener):
     def on_start(self) -> None:
         scrobbler_config = cast("ScrobblerConfig", self.config["scrobbler"])
         try:
-            self.lastfm = pylast.LastFMNetwork(
+            self.network = pylast.LastFMNetwork(
                 api_key=API_KEY,
                 api_secret=API_SECRET,
                 username=scrobbler_config["username"],
@@ -67,7 +67,7 @@ class ScrobblerFrontend(pykka.ThreadingActor, CoreListener):
         self.last_start_time = dt.datetime.now(tz=dt.UTC)
         logger.debug(f"Now playing track: {artists} - {track.name}")
         try:
-            self.lastfm.update_now_playing(
+            self.network.update_now_playing(
                 artists,
                 (track.name or ""),
                 album=((track.album and track.album.name) or ""),
@@ -109,7 +109,7 @@ class ScrobblerFrontend(pykka.ThreadingActor, CoreListener):
         artists = ", ".join(sorted([a.name for a in track.artists if a.name]))
         logger.debug(f"Scrobbling track: {artists} - {track.name}")
         try:
-            self.lastfm.scrobble(
+            self.network.scrobble(
                 artists,
                 (track.name or ""),
                 round(self.last_start_time.timestamp()),

--- a/src/mopidy_scrobbler/frontend.py
+++ b/src/mopidy_scrobbler/frontend.py
@@ -9,6 +9,8 @@ import pylast
 from mopidy.core import CoreListener
 from mopidy.httpclient import format_proxy
 
+from mopidy_scrobbler.types import NetworkConfig
+
 if TYPE_CHECKING:
     from mopidy.config import Config
     from mopidy.core import CoreProxy
@@ -19,8 +21,22 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-API_KEY = "2236babefa8ebb3d93ea467560d00d04"
-API_SECRET = "94d9a09c0cd5be955c4afaeaffcaefcd"  # noqa: S105
+NETWORK_CONFIG = {
+    "lastfm": NetworkConfig(
+        name="Last.fm",
+        network_class=pylast.LastFMNetwork,
+        api_key="2236babefa8ebb3d93ea467560d00d04",
+        api_secret="94d9a09c0cd5be955c4afaeaffcaefcd",  # noqa: S106
+    ),
+    "librefm": NetworkConfig(
+        name="Libre.fm",
+        network_class=pylast.LibreFMNetwork,
+        #
+        # Libre.fm API key may expire 2031-04-25
+        api_key="339f358f9ba0dc49e00a400c8cdd773e",
+        api_secret="4c3d7cf6f6379cb86e4c08231a347cda",  # noqa: S106
+    ),
+}
 
 # Limits from https://www.last.fm/api/scrobbling
 MIN_DURATION = dt.timedelta(seconds=30)
@@ -29,7 +45,7 @@ MIN_PLAYED_PERCENT = 50
 
 
 class ScrobblerFrontend(pykka.ThreadingActor, CoreListener):
-    network: pylast.LastFMNetwork
+    network: pylast.LastFMNetwork | pylast.LibreFMNetwork
     last_start_time: dt.datetime | None
 
     @override
@@ -46,17 +62,18 @@ class ScrobblerFrontend(pykka.ThreadingActor, CoreListener):
     @override
     def on_start(self) -> None:
         scrobbler_config = cast("ScrobblerConfig", self.config["scrobbler"])
+        network_config = NETWORK_CONFIG[scrobbler_config["network"]]
         try:
-            self.network = pylast.LastFMNetwork(
-                api_key=API_KEY,
-                api_secret=API_SECRET,
+            self.network = network_config.network_class(
+                api_key=network_config.api_key,
+                api_secret=network_config.api_secret,
                 username=scrobbler_config["username"],
                 password_hash=pylast.md5(scrobbler_config["password"]),
                 proxy=format_proxy(self.config["proxy"]),
             )
-            logger.info("Scrobbler connected to Last.fm")
+            logger.info(f"Scrobbler connected to {network_config.name}")
         except pylast.PyLastError as exc:
-            logger.error(f"Error during Last.fm setup: {exc}")  # noqa: TRY400
+            logger.error(f"Error during {network_config.name} setup: {exc}")  # noqa: TRY400
             self.stop()
 
     @override

--- a/src/mopidy_scrobbler/types.py
+++ b/src/mopidy_scrobbler/types.py
@@ -1,7 +1,22 @@
-from typing import TypedDict
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Literal, TypedDict
+
+if TYPE_CHECKING:
+    import pylast
 
 
 class ScrobblerConfig(TypedDict):
     enabled: bool
+    network: Literal["lastfm", "librefm"]
     username: str
     password: str
+
+
+@dataclass
+class NetworkConfig:
+    name: str
+    network_class: type[pylast.LastFMNetwork | pylast.LibreFMNetwork]
+    api_key: str
+    api_secret: str

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -11,6 +11,7 @@ def test_get_default_config() -> None:
 
     assert "[scrobbler]" in config
     assert "enabled = true" in config
+    assert "network = lastfm" in config
     assert "username =" in config
     assert "password =" in config
 
@@ -20,6 +21,7 @@ def test_get_config_schema() -> None:
 
     schema = ext.get_config_schema()
 
+    assert "network" in schema
     assert "username" in schema
     assert "password" in schema
 

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import datetime as dt
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 from unittest import mock
 from uuid import UUID
 
@@ -10,23 +10,35 @@ import pytest
 from mopidy import models
 from mopidy.types import DurationMs, TracklistId, Uri
 
-from mopidy_scrobbler.frontend import API_KEY, API_SECRET, ScrobblerFrontend
+from mopidy_scrobbler.frontend import NETWORK_CONFIG, ScrobblerFrontend
 
 if TYPE_CHECKING:
     from collections.abc import Generator
 
 
 @pytest.fixture
-def pylast_mock() -> Generator[mock.MagicMock]:
-    with mock.patch("mopidy_scrobbler.frontend.pylast", spec=pylast) as m:
-        m.PyLastError = pylast.PyLastError
-        yield m
+def pylast_mock(
+    monkeypatch: pytest.MonkeyPatch,
+) -> Generator[mock.MagicMock]:
+    with mock.patch("mopidy_scrobbler.frontend.pylast", spec=pylast) as mock_obj:
+        mock_obj.PyLastError = pylast.PyLastError
+        for config in NETWORK_CONFIG.values():
+            monkeypatch.setattr(
+                config,
+                "network_class",
+                getattr(mock_obj, config.network_class.__name__),
+            )
+        yield mock_obj
 
 
 @pytest.fixture
 def frontend() -> ScrobblerFrontend:
     config = {
-        "scrobbler": {"username": "alice", "password": "secret"},
+        "scrobbler": {
+            "network": "lastfm",
+            "username": "alice",
+            "password": "secret",
+        },
         "proxy": {
             "scheme": None,
             "hostname": None,
@@ -42,28 +54,37 @@ def frontend() -> ScrobblerFrontend:
     )
 
 
-def test_on_start_creates_lastfm_network(
+@pytest.mark.parametrize("network_name", list(NETWORK_CONFIG))
+def test_on_start_creates_network(
     pylast_mock: mock.MagicMock,
     frontend: ScrobblerFrontend,
+    network_name: str,
 ) -> None:
     pylast_mock.md5.return_value = mock.sentinel.password_hash
+    network_config = NETWORK_CONFIG[network_name]
+    frontend.config["scrobbler"]["network"] = network_name  # pyright: ignore[reportIndexIssue]
 
     frontend.on_start()
 
-    pylast_mock.LastFMNetwork.assert_called_with(
-        api_key=API_KEY,
-        api_secret=API_SECRET,
+    network_class = cast("mock.MagicMock", network_config.network_class)
+    network_class.assert_called_with(
+        api_key=network_config.api_key,
+        api_secret=network_config.api_secret,
         username="alice",
         password_hash=mock.sentinel.password_hash,
         proxy=None,
     )
 
 
+@pytest.mark.parametrize("network_name", list(NETWORK_CONFIG))
 def test_on_start_passes_configured_proxy(
     pylast_mock: mock.MagicMock,
     frontend: ScrobblerFrontend,
+    network_name: str,
 ) -> None:
     pylast_mock.md5.return_value = mock.sentinel.password_hash
+    network_config = NETWORK_CONFIG[network_name]
+    frontend.config["scrobbler"]["network"] = network_name  # pyright: ignore[reportIndexIssue]
     frontend.config["proxy"] = {  # pyright: ignore[reportIndexIssue]
         "scheme": "https",
         "hostname": "proxy.example.com",
@@ -74,9 +95,10 @@ def test_on_start_passes_configured_proxy(
 
     frontend.on_start()
 
-    pylast_mock.LastFMNetwork.assert_called_with(
-        api_key=API_KEY,
-        api_secret=API_SECRET,
+    network_class = cast("mock.MagicMock", network_config.network_class)
+    network_class.assert_called_with(
+        api_key=network_config.api_key,
+        api_secret=network_config.api_secret,
         username="alice",
         password_hash=mock.sentinel.password_hash,
         proxy="https://bob:hunter2@proxy.example.com:8080",

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -100,7 +100,7 @@ def test_track_playback_started_updates_now_playing(
     pylast_mock: mock.MagicMock,
     frontend: ScrobblerFrontend,
 ) -> None:
-    frontend.lastfm = mock.Mock(spec=pylast.LastFMNetwork)
+    frontend.network = mock.Mock(spec=pylast.LastFMNetwork)
     artists = frozenset([models.Artist(name="ABC"), models.Artist(name="XYZ")])
     album = models.Album(name="The Collection")
     track = models.Track(
@@ -116,7 +116,7 @@ def test_track_playback_started_updates_now_playing(
 
     frontend.track_playback_started(tl_track)
 
-    frontend.lastfm.update_now_playing.assert_called_with(
+    frontend.network.update_now_playing.assert_called_with(
         "ABC, XYZ",
         "One Two Three",
         duration="180",
@@ -130,13 +130,13 @@ def test_track_playback_started_has_default_values(
     pylast_mock: mock.MagicMock,
     frontend: ScrobblerFrontend,
 ) -> None:
-    frontend.lastfm = mock.Mock(spec=pylast.LastFMNetwork)
+    frontend.network = mock.Mock(spec=pylast.LastFMNetwork)
     track = models.Track(uri=Uri("test:foo"))
     tl_track = models.TlTrack(track=track, tlid=TracklistId(17))
 
     frontend.track_playback_started(tl_track)
 
-    frontend.lastfm.update_now_playing.assert_called_with(
+    frontend.network.update_now_playing.assert_called_with(
         "", "", duration="0", album="", track_number="0", mbid=""
     )
 
@@ -145,9 +145,9 @@ def test_track_playback_started_catches_pylast_error(
     pylast_mock: mock.MagicMock,
     frontend: ScrobblerFrontend,
 ) -> None:
-    frontend.lastfm = mock.Mock(spec=pylast.LastFMNetwork)
+    frontend.network = mock.Mock(spec=pylast.LastFMNetwork)
     pylast_mock.NetworkError = pylast.NetworkError
-    frontend.lastfm.update_now_playing.side_effect = pylast.NetworkError(None, "foo")
+    frontend.network.update_now_playing.side_effect = pylast.NetworkError(None, "foo")
     track = models.Track(uri=Uri("test:foo"))
     tl_track = models.TlTrack(track=track, tlid=TracklistId(17))
 
@@ -159,7 +159,7 @@ def test_track_playback_ended_scrobbles_played_track(
     frontend: ScrobblerFrontend,
 ) -> None:
     frontend.last_start_time = dt.datetime(1970, 1, 1, 0, 2, 3, tzinfo=dt.UTC)
-    frontend.lastfm = mock.Mock(spec=pylast.LastFMNetwork)
+    frontend.network = mock.Mock(spec=pylast.LastFMNetwork)
     artists = frozenset([models.Artist(name="ABC"), models.Artist(name="XYZ")])
     album = models.Album(name="The Collection")
     track = models.Track(
@@ -175,7 +175,7 @@ def test_track_playback_ended_scrobbles_played_track(
 
     frontend.track_playback_ended(tl_track, DurationMs(150000))
 
-    frontend.lastfm.scrobble.assert_called_with(
+    frontend.network.scrobble.assert_called_with(
         "ABC, XYZ",
         "One Two Three",
         123,
@@ -191,13 +191,13 @@ def test_track_playback_ended_has_default_values(
     frontend: ScrobblerFrontend,
 ) -> None:
     frontend.last_start_time = dt.datetime(1970, 1, 1, 0, 2, 3, tzinfo=dt.UTC)
-    frontend.lastfm = mock.Mock(spec=pylast.LastFMNetwork)
+    frontend.network = mock.Mock(spec=pylast.LastFMNetwork)
     track = models.Track(uri=Uri("test:foo"), length=DurationMs(180432))
     tl_track = models.TlTrack(track=track, tlid=TracklistId(17))
 
     frontend.track_playback_ended(tl_track, DurationMs(150000))
 
-    frontend.lastfm.scrobble.assert_called_with(
+    frontend.network.scrobble.assert_called_with(
         "",
         "",
         123,
@@ -212,48 +212,48 @@ def test_does_not_scrobble_tracks_shorter_than_30_sec(
     pylast_mock: mock.MagicMock,
     frontend: ScrobblerFrontend,
 ) -> None:
-    frontend.lastfm = mock.Mock(spec=pylast.LastFMNetwork)
+    frontend.network = mock.Mock(spec=pylast.LastFMNetwork)
     track = models.Track(uri=Uri("test:foo"), length=DurationMs(20432))
     tl_track = models.TlTrack(track=track, tlid=TracklistId(17))
 
     frontend.track_playback_ended(tl_track, DurationMs(20432))
 
-    assert frontend.lastfm.scrobble.call_count == 0
+    assert frontend.network.scrobble.call_count == 0
 
 
 def test_does_not_scrobble_if_played_less_than_half(
     pylast_mock: mock.MagicMock,
     frontend: ScrobblerFrontend,
 ) -> None:
-    frontend.lastfm = mock.Mock(spec=pylast.LastFMNetwork)
+    frontend.network = mock.Mock(spec=pylast.LastFMNetwork)
     track = models.Track(uri=Uri("test:foo"), length=DurationMs(180432))
     tl_track = models.TlTrack(track=track, tlid=TracklistId(17))
 
     frontend.track_playback_ended(tl_track, DurationMs(60432))
 
-    assert frontend.lastfm.scrobble.call_count == 0
+    assert frontend.network.scrobble.call_count == 0
 
 
 def test_does_scrobble_if_played_not_half_but_240_sec(
     pylast_mock: mock.MagicMock,
     frontend: ScrobblerFrontend,
 ) -> None:
-    frontend.lastfm = mock.Mock(spec=pylast.LastFMNetwork)
+    frontend.network = mock.Mock(spec=pylast.LastFMNetwork)
     track = models.Track(uri=Uri("test:foo"), length=DurationMs(180432))
     tl_track = models.TlTrack(track=track, tlid=TracklistId(17))
 
     frontend.track_playback_ended(tl_track, DurationMs(241432))
 
-    assert frontend.lastfm.scrobble.call_count == 1
+    assert frontend.network.scrobble.call_count == 1
 
 
 def test_track_playback_ended_catches_pylast_error(
     pylast_mock: mock.MagicMock,
     frontend: ScrobblerFrontend,
 ) -> None:
-    frontend.lastfm = mock.Mock(spec=pylast.LastFMNetwork)
+    frontend.network = mock.Mock(spec=pylast.LastFMNetwork)
     pylast_mock.NetworkError = pylast.NetworkError
-    frontend.lastfm.scrobble.side_effect = pylast.NetworkError(None, "foo")
+    frontend.network.scrobble.side_effect = pylast.NetworkError(None, "foo")
     track = models.Track(uri=Uri("test:foo"), length=DurationMs(180432))
     tl_track = models.TlTrack(track=track, tlid=TracklistId(17))
 


### PR DESCRIPTION
This adds support for Libre.fm, the only other scrobbling network supported out of the box by our dependency pylast.

Fixes #5